### PR TITLE
Update base to ruby:2.6.3-slim, terraform-landscape to 0.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:2.4.3-slim
+FROM ruby:2.6.3-slim
 
-ENV TERRAFORM_LANDSCAPE_VERSION=0.1.17
+ENV TERRAFORM_LANDSCAPE_VERSION=0.3.2
 
-RUN gem install --no-document --no-ri terraform_landscape:${TERRAFORM_LANDSCAPE_VERSION}
+RUN gem install --no-document terraform_landscape:${TERRAFORM_LANDSCAPE_VERSION}
 
 ENTRYPOINT ["landscape"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Dockerized gem from https://github.com/coinbase/terraform-landscape
 
 ## Supported tags
 
+* 0.3.2-slim - ruby:2.6.3-slim
 * 0.1.17-slim - ruby:2.4.3-slim
 * 0.1.17-alpine - ruby:2.4.2-alpine
 * 0.1.17 - ruby:2.4.2-alpine


### PR DESCRIPTION
Requestor/Jira: https://jira.airhelp.com/browse/AIR-27036
Risk (low/med/high): low
Description/Why: Terraform-landscape needs upgrade to correctly parse output from AWS provider 2.0. Newer Ruby 2.5< deprecates --no-ri, as --no-document supersedes it.